### PR TITLE
python3 compatibility

### DIFF
--- a/antigate/__init__.py
+++ b/antigate/__init__.py
@@ -11,6 +11,7 @@ from xmltodict import parse
 from sys import exc_info
 from time import sleep
 import base64
+import six
 
 from grab import Grab, UploadFile
 
@@ -73,7 +74,11 @@ class AntiGate(object):
             'date': datetime.now().strftime('%Y-%m-%d')})
 
     def _body(self, key):
-        body = self.g.response.body.split('|')
+        if six.PY2:
+            body = self.g.response.body.split('|')
+        else:
+            body = self.g.response.body.decode('utf-8').split('|')
+
         if len(body) != 2 or body[0] != 'OK':
             raise AntiGateError(body[0])
         setattr(self, key, body[1])

--- a/requirements/package.txt
+++ b/requirements/package.txt
@@ -2,3 +2,4 @@ grab==0.4.13
 lxml==3.2.4
 pycurl==7.19.0.2
 xmltodict==0.8.3
+six==1.9.0


### PR DESCRIPTION
I tried to run antigate under python 3.4 and it's failed.
This small fix will solve the problem.
six is already required by grab package thus you don't need to install any additional packages.